### PR TITLE
Use `Option<AccountId>` for owner

### DIFF
--- a/ownable/build.sh
+++ b/ownable/build.sh
@@ -7,7 +7,7 @@ PROJNAME=ownable
 # rm Cargo.lock
 
 CARGO_INCREMENTAL=0 &&
-cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/ownable/src/lib.rs
+++ b/ownable/src/lib.rs
@@ -3,7 +3,6 @@
 use ink_lang::contract;
 use ink_core::storage;
 use ink_core::env::{self, AccountId};
-use std::convert::TryFrom;
 
 use parity_codec::{
     Decode,
@@ -18,61 +17,69 @@ enum Event {
     },
 }
 
-fn transer_ownership_event (event: Event) {
+fn deposit_event (event: Event) {
     env::deposit_raw_event(&event.encode()[..])
 }
+
 contract! {
-    
     struct Ownable {
-        owner: storage::Value<AccountId>,
+        owner: storage::Value<Option<AccountId>>,
     }
 
     impl Deploy for Ownable {
-        
         fn deploy(&mut self) {
-            self.owner.set(env.caller());
+            self.owner.set(Some(env.caller()));
+            deposit_event(Event::OwnershipTransferred {
+               from: None,
+               to: Some(env::caller())
+            });
         }
     }
 
     impl Ownable {
-
-    
         pub (external) fn is_owner(&mut self) -> bool {
-            env::caller() == *self.owner 
-         }
+            if self.owner.is_some() {
+                return env::caller() == self.owner.unwrap()
+            }
+            false
+        }
 
-       pub (external) fn get_owner(&mut self) -> AccountId {
-           *self.owner
-       }
+        pub (external) fn get_owner(&mut self) -> Option<AccountId> {
+            // Need to remove `--features generate-api-description` from build.sh
+            // Known bug, will be fixed in the future
+            *self.owner
+        }
 
-       fn only_owner(&mut self, caller: AccountId) -> bool {
-           if caller == *self.owner {
-               true
-           } else {
-               panic!("Must be called from owner account");
-           }
-       }
-
-       pub (external) fn transfer_ownership(&mut self, new_owner: AccountId){
-           self.only_owner(env::caller());
-           self.owner.set(new_owner); 
-           transer_ownership_event(Event::OwnershipTransferred {
+        pub (external) fn transfer_ownership(&mut self, new_owner: AccountId) -> bool {
+            assert!(self.only_owner(env::caller()));
+            self.owner.set(Some(new_owner));
+            deposit_event(Event::OwnershipTransferred {
                from: Some(env::caller()),
                to: Some(new_owner)
-           });
-       }
+            });
+            true
+        }
 
-    //not sure if this is the most secure way to do this.......looking for advice
-       pub (external) fn renounce_ownership(&mut self) {
-          self.only_owner(env::caller());
-          self.owner.set(AccountId::try_from([0x0; 32]).unwrap());
-          transer_ownership_event(Event::OwnershipTransferred {
-              from: Some(env::caller()),
-              to: Some(AccountId::try_from([0x0; 32]).unwrap())
-          })
+        pub (external) fn renounce_ownership(&mut self) -> bool {
+            assert!(self.only_owner(env::caller()));
+            self.owner.set(None);
+            deposit_event(Event::OwnershipTransferred {
+                from: Some(env::caller()),
+                to: None
+            });
+            true
+        }
+    }
 
-       }
-    
+    impl Ownable {
+        fn only_owner(&mut self, caller: AccountId) -> bool {
+            if self.owner.is_some() {
+                if caller == self.owner.unwrap() {
+                    return true
+                }
+            }
+            false
+        }
     }
 }
 
@@ -81,60 +88,51 @@ mod tests {
     use super::*;
     use std::convert::TryFrom;
 
-      
     #[test]
-
     fn is_owner() {
-        let _bob = AccountId::try_from([0x1; 32]).unwrap();
+        let bob = AccountId::try_from([0x1; 32]).unwrap();
 
         let mut contract = Ownable::deploy_mock();
         assert_eq!(contract.is_owner(), true);
-        env::test::set_caller(_bob);
+        env::test::set_caller(bob);
         assert_eq!(contract.is_owner(), false);
 
     }
     
     #[test]
-
     fn get_owner() {
-        let _alice = AccountId::try_from([0x0; 32]).unwrap();
-        let _bob = AccountId::try_from([0x1; 32]).unwrap();
-
+        let alice = AccountId::try_from([0x0; 32]).unwrap();
 
         let mut contract = Ownable::deploy_mock();
-        assert_eq!(contract.get_owner(), _alice);
-        assert_ne!(contract.get_owner(), _bob);
+        assert_eq!(contract.get_owner(), Some(alice));
+    }
 
+    #[test]
+    fn transfer_ownership_works() {
+        let bob = AccountId::try_from([0x1; 32]).unwrap();
 
+        let mut contract = Ownable::deploy_mock();
+        assert!(contract.transfer_ownership(bob));
+        assert_eq!(contract.get_owner(), Some(bob));
+    }
+
+    #[test]
+    #[should_panic]
+    fn transfer_ownership_fails() {
+        let alice = AccountId::try_from([0x0; 32]).unwrap();
+        let bob = AccountId::try_from([0x1; 32]).unwrap();
+
+        let mut contract = Ownable::deploy_mock();
+        assert!(contract.transfer_ownership(bob));
+        // This line should panic since non-owner cannot call this function.
+        contract.transfer_ownership(alice);
     }
 
     #[test]
 
-    fn transfer_ownership() {
-        let _alice = AccountId::try_from([0x0; 32]).unwrap();
-        let _bob = AccountId::try_from([0x1; 32]).unwrap();
-
+    fn renounce_ownership_works()  {
         let mut contract = Ownable::deploy_mock();
-        contract.transfer_ownership(_bob);
-        // will fail
-        // contract.transfer_ownership(alice);        
-
+        assert!(contract.renounce_ownership());
+        assert_eq!(contract.get_owner(), None);
     }
-
-    #[test]
-
-    fn renounce_ownership()  {
-        let _bob = AccountId::try_from([0x1; 32]).unwrap();
-
-        let mut contract = Ownable::deploy_mock();
-        contract.renounce_ownership();
-
-        // will fail
-        // env::test::set_caller(bob);
-        // contract.renounce_ownership();
-
-    }
-
-
-
 }


### PR DESCRIPTION
Note that I had to remove the `generate-api-description` feature in the `build.sh` script due to a known bug. This means an ABI file is not created for this contract automagically, but that will be fixed and can be updated later.